### PR TITLE
fix: github actions: use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,4 +38,4 @@ jobs:
       with:
         charts_dir: "helm" 
       env:
-        CR_TOKEN: "${{ secrets.CR_TOKEN }}"
+        CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
The bug that required a separate personal access token has long been fixed; we can now just use the normal token that actions passes in.