### PR TITLE
Make resource requests configurable. Defaults kept.

### DIFF
--- a/helm/bits/templates/bits.yaml
+++ b/helm/bits/templates/bits.yaml
@@ -65,10 +65,16 @@ spec:
         - name: bits-assets
           mountPath: /assets/
         {{ end }}
+        {{- if or .Values.global.resources.cpu .Values.global.resources.memory }}
         resources:
           requests:
-            cpu: 800m
-            memory: 150Mi
+          {{- if .Values.global.resources.cpu }}
+            cpu: {{ .Values.global.resources.cpu }}
+          {{ end }}
+          {{- if .Values.global.resources.memory }}
+            memory: {{ .Values.global.resources.memory }}
+          {{- end }}
+        {{- end }}
       {{- if .Values.download_eirinifs }}
       initContainers:
       - name: "download-eirini-rootfs"

--- a/helm/bits/templates/bits.yaml
+++ b/helm/bits/templates/bits.yaml
@@ -65,15 +65,17 @@ spec:
         - name: bits-assets
           mountPath: /assets/
         {{ end }}
-        {{- if or .Values.global.resources.cpu .Values.global.resources.memory }}
+        {{- with .Values.resources }}
+        {{- if or .cpu .memory }}
         resources:
           requests:
-          {{- if .Values.global.resources.cpu }}
-            cpu: {{ .Values.global.resources.cpu }}
-          {{ end }}
-          {{- if .Values.global.resources.memory }}
-            memory: {{ .Values.global.resources.memory }}
-          {{- end }}
+            {{- with .cpu }}
+            cpu: {{ . }}
+            {{ end }}
+            {{- with .memory }}
+            memory: {{ . }}
+            {{- end }}
+        {{- end }}
         {{- end }}
       {{- if .Values.download_eirinifs }}
       initContainers:

--- a/helm/bits/values.yaml
+++ b/helm/bits/values.yaml
@@ -18,6 +18,9 @@ global:
     rootfs_downloader: eirini/rootfs-downloader:2.32.0@sha256:6ae511688a27a453dcf31bf5a3bd7287ba99233e1586c7aeb78c87a18c68dbe4
   labels: {}
   annotations: {}
+  resources:
+    cpu: 800m
+    memory: 150mi
 
 tls_secret_name: private-registry-cert
 # set to true if you wish to use a pre-populated

--- a/helm/bits/values.yaml
+++ b/helm/bits/values.yaml
@@ -18,9 +18,10 @@ global:
     rootfs_downloader: eirini/rootfs-downloader:2.32.0@sha256:6ae511688a27a453dcf31bf5a3bd7287ba99233e1586c7aeb78c87a18c68dbe4
   labels: {}
   annotations: {}
-  resources:
-    cpu: 800m
-    memory: 150mi
+
+resources:
+  cpu: 800m
+  memory: 150Mi
 
 tls_secret_name: private-registry-cert
 # set to true if you wish to use a pre-populated


### PR DESCRIPTION
See cloudfoundry-incubator/kubecf#861

Make resource requests configurable.
The current defaults are kept, now in the `values.yaml` for the chart.
Setting the requests to `nil` (`~`) disables them completely.

Tested locally in a minikube that changes to the defaults in the kubecf values.yaml are properly propagated into the bits pod.
