### PR TITLE
Change bits service from loadbalanced to nodePort.

### DIFF
--- a/helm/bits/templates/bits-config.yaml
+++ b/helm/bits/templates/bits-config.yaml
@@ -11,14 +11,14 @@ stringData:
     private_endpoint: "https://bits.{{ .Release.Namespace }}.svc.cluster.local"
     {{- if .Values.ingress.use }}
     public_endpoint: "https://registry.{{ .Values.ingress.endpoint }}:443"
-    {{- else if .Values.services.loadbalanced }}
+    {{- else if .Values.services.nodePort }}
     public_endpoint: "https://registry.{{ .Values.env.DOMAIN }}:6666"
     {{- else }}
     public_endpoint: "https://bits.{{ index .Values.kube.external_ips 0 }}.nip.io"
     {{- end }}
     {{- if .Values.ingress.use }}
     registry_endpoint: "https://registry.{{ .Values.ingress.endpoint }}"
-    {{- else if .Values.services.loadbalanced }}
+    {{- else if .Values.services.nodePort }}
     registry_endpoint: "https://registry.{{ .Values.env.DOMAIN }}"
     {{- else }}
     registry_endpoint: "https://registry.{{ index .Values.kube.external_ips 0 }}.nip.io"
@@ -50,7 +50,7 @@ stringData:
         private_endpoint: https://{{ .Values.blobstore.serviceName }}.{{ .Release.Namespace }}.svc.cluster.local:4443
         {{- if .Values.ingress.use }}
         public_endpoint: https://blobstore.{{ .Values.ingress.endpoint }}
-        {{- else if .Values.services.loadbalanced }}
+        {{- else if .Values.services.nodePort }}
         public_endpoint: https://blobstore.{{ .Values.env.DOMAIN }}
         {{- else }}
         public_endpoint: https://blobstore.{{ index .Values.kube.external_ips 0 }}.nip.io

--- a/helm/bits/templates/bits-config.yaml
+++ b/helm/bits/templates/bits-config.yaml
@@ -12,14 +12,14 @@ stringData:
     {{- if .Values.ingress.use }}
     public_endpoint: "https://registry.{{ .Values.ingress.endpoint }}:443"
     {{- else if .Values.services.nodePort }}
-    public_endpoint: "https://registry.{{ .Values.env.DOMAIN }}:6666"
+    public_endpoint: "https://registry.{{ .Values.env.DOMAIN }}:{{ .Values.services.nodePort }}"
     {{- else }}
     public_endpoint: "https://bits.{{ index .Values.kube.external_ips 0 }}.nip.io"
     {{- end }}
     {{- if .Values.ingress.use }}
     registry_endpoint: "https://registry.{{ .Values.ingress.endpoint }}"
     {{- else if .Values.services.nodePort }}
-    registry_endpoint: "https://registry.{{ .Values.env.DOMAIN }}"
+    registry_endpoint: "https://registry.{{ .Values.env.DOMAIN }}:{{ .Values.services.nodePort }}"
     {{- else }}
     registry_endpoint: "https://registry.{{ index .Values.kube.external_ips 0 }}.nip.io"
     {{- end }}
@@ -51,7 +51,7 @@ stringData:
         {{- if .Values.ingress.use }}
         public_endpoint: https://blobstore.{{ .Values.ingress.endpoint }}
         {{- else if .Values.services.nodePort }}
-        public_endpoint: https://blobstore.{{ .Values.env.DOMAIN }}
+        public_endpoint: "https://blobstore.{{ .Values.env.DOMAIN }}:{{ .Values.services.nodePort }}"
         {{- else }}
         public_endpoint: https://blobstore.{{ index .Values.kube.external_ips 0 }}.nip.io
         {{- end }}

--- a/helm/bits/templates/bits.yaml
+++ b/helm/bits/templates/bits.yaml
@@ -112,7 +112,9 @@ spec:
     - port: {{ if .Values.ingress.use }}8888{{ else }}6666{{ end }}
       protocol: TCP
       targetPort: {{ if .Values.ingress.use }}8888{{ else }}6666{{ end }}
-      nodePort: {{ .Values.services.nodePort }}
+      {{- with .Values.services.nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
       name: bits
   selector:
     name: "bits"

--- a/helm/bits/templates/bits.yaml
+++ b/helm/bits/templates/bits.yaml
@@ -105,19 +105,20 @@ metadata:
     external-dns.alpha.kubernetes.io/hostname: registry.{{ .Values.env.DOMAIN }}
 {{- end }}
 spec:
-{{- if and (not .Values.ingress.use) (not .Values.services.loadbalanced) }}
+{{- if and (not .Values.ingress.use) (not .Values.services.nodePort) }}
   externalIPs: {{ .Values.kube.external_ips | toJson }}
 {{- end }}
   ports:
     - port: {{ if .Values.ingress.use }}8888{{ else }}6666{{ end }}
       protocol: TCP
       targetPort: {{ if .Values.ingress.use }}8888{{ else }}6666{{ end }}
+      nodePort: {{ .Values.services.nodePort }}
       name: bits
   selector:
     name: "bits"
 
-  {{- if .Values.services.loadbalanced }}
-  type: "LoadBalancer"
+  {{- if .Values.services.nodePort }}
+  type: "NodePort"
   {{- end }}
 
 # Ingress

--- a/helm/bits/values.yaml
+++ b/helm/bits/values.yaml
@@ -33,7 +33,7 @@ kube:
   external_ips: []
 
 services:
-  loadbalanced: false
+  nodePort: 31666
 
 secrets:
   BITS_SERVICE_SECRET: secret


### PR DESCRIPTION
## Description

Removed `loadbalanced` property.
Added `nodePort` property.
Changed templates to trigger on `nodePort`. Removed all references to `loadbalanced`.

## Motivation and Context

See https://github.com/cloudfoundry-incubator/kubecf/issues/792

## How Has This Been Tested?

Local minikube, SA eirini. Smoke tests run manually.
