### PR TITLE
feat: helm: Do not assume .cluster.local domain

### DIFF
--- a/helm/bits/templates/bits-config.yaml
+++ b/helm/bits/templates/bits-config.yaml
@@ -8,7 +8,7 @@ stringData:
   bits-config-key: |
     logging:
       level: debug
-    private_endpoint: "https://bits.{{ .Release.Namespace }}.svc.cluster.local"
+    private_endpoint: "https://bits.{{ .Release.Namespace }}.svc"
     {{- if .Values.ingress.use }}
     public_endpoint: "https://registry.{{ .Values.ingress.endpoint }}:443"
     {{- else if .Values.services.nodePort }}
@@ -47,7 +47,11 @@ stringData:
       blobstore_type: webdav
       webdav_config: &webdav_config
         directory_key: cc-buildpacks
-        private_endpoint: https://{{ .Values.blobstore.serviceName }}.{{ .Release.Namespace }}.svc.cluster.local:4443
+        {{- $blobstore_service := .Values.blobstore.serviceName }}
+        {{- if contains "." $blobstore_service | not }}
+        {{- $blobstore_service = printf "%s.%s.svc" $blobstore_service .Release.Namespace }}
+        {{- end }}
+        private_endpoint: https://{{ $blobstore_service }}:4443
         {{- if .Values.ingress.use }}
         public_endpoint: https://blobstore.{{ .Values.ingress.endpoint }}
         {{- else if .Values.services.nodePort }}


### PR DESCRIPTION
Fix up the helm chart so that we do not assume the Kubernetes cluster domain is always `.cluster.local`.  Also allows override of the blobstore hostname (so that it can be external to the deployment).

This is required for https://github.com/cloudfoundry-incubator/kubecf/issues/872