### PR TITLE
fix: helm: drop port number in registry_endpoint

### DIFF
--- a/helm/bits/templates/bits-config.yaml
+++ b/helm/bits/templates/bits-config.yaml
@@ -19,7 +19,8 @@ stringData:
     {{- if .Values.ingress.use }}
     registry_endpoint: "https://registry.{{ .Values.ingress.endpoint }}"
     {{- else if .Values.services.nodePort }}
-    registry_endpoint: "https://registry.{{ .Values.env.DOMAIN }}:{{ .Values.services.nodePort }}"
+    # The registry endpoint must not include the port
+    registry_endpoint: "https://registry.{{ .Values.env.DOMAIN }}"
     {{- else }}
     registry_endpoint: "https://registry.{{ index .Values.kube.external_ips 0 }}.nip.io"
     {{- end }}


### PR DESCRIPTION
If we put the port number on registry_endpoint, we end up never being able to pull the images from it.  It is unclear why this is the case.

This was last changed in 1e05c56e27fc4fd4b7d4d3ac2226306029f0f315 (because I asked for it); it's still unclear why this should be the case, as the endpoint passed into the configmap does not have a port with the change, but somehow adding it breaks the routing.